### PR TITLE
Fixed start/end dates in redux state

### DIFF
--- a/src/actions/libraryActions.js
+++ b/src/actions/libraryActions.js
@@ -62,7 +62,7 @@ export const updateBookUserRating = (bookId, rating) => dispatch => {
 	dispatch({ type: UPDATE_BOOK_USER_RATING, payload: {bookId, rating}})
 }
 
-export const updateBookValue = (bookId, field, value) => dispatch => {
+export const updateSingleBookField = (bookId, field, value) => dispatch => {
 	dispatch({ type: UPDATE_SINGLE_BOOK_FIELD, payload: {bookId, field, value}})
 }
 

--- a/src/components/common/BookCard.js
+++ b/src/components/common/BookCard.js
@@ -6,6 +6,7 @@ import {
     updateBookFavorite,
     updateBookReadingStatus,
     updateBookUserRating,
+    updateSingleBookField,
     moveBookFromShelf
 } from '../../actions/index';
 import { updateBookItem, updateDates, sendUpTheFlares, updateUserRating } from '../../utils/helpers';
@@ -129,6 +130,9 @@ const BookCard = props => {
     const handleDates = (date, dateString, whichDate) => {
         updateDates(localStorage.getItem('id'), readrrId, dateString, whichDate)
             .then(result => {
+                console.log(result)
+                if(result.data.dateStarted) props.updateSingleBookField(readrrId, 'dateStarted', result.data.dateStarted.split('T')[0]);
+                if(result.data.dateEnded) props.updateSingleBookField(readrrId, 'dateEnded', result.data.dateEnded.split('T')[0]);
                 setLibraryBook({
                     ...libraryBook,
                     dateStarted: result.data.dateStarted && result.data.dateStarted.split('T')[0],
@@ -225,5 +229,6 @@ export default connect(mapStateToProps, {
     updateBookFavorite,
     updateBookReadingStatus,
     updateBookUserRating,
+    updateSingleBookField,
     moveBookFromShelf
 })(BookCard);

--- a/src/reducers/library.js
+++ b/src/reducers/library.js
@@ -91,6 +91,8 @@ export const reducer = (state = initialState, action) => {
 							...book,
 							[action.payload.field]: action.payload.value
 						}
+					} else {
+						return book;
 					}
 				})
 			}


### PR DESCRIPTION
### Description

Fixes # (issue)
Fixed an issue with dateStarted and dateEnded input.  When a user would enter a date (start or end) and then move the book another shelf (to be read, in progress, finished) the date would be lost. Now the redux store is updated when the date is updated to reflect the selected dates.

### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

### How Has This Been Tested?

- [ ] Test A
- [ ] Test B

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
