### PR TITLE
Update BookCardComponents Button

### DIFF
--- a/src/components/Book/BookCardComponents.js
+++ b/src/components/Book/BookCardComponents.js
@@ -70,7 +70,7 @@ export const BookThumbnail = ({ book, source, library, userID }) => {
       </div>
 
       <Dropdown overlay={dropDown(setStatus, source)} trigger={['click']}>
-        <Button className={label === 'Track this' ? 'orange' : 'green'}>
+        <Button className='orange'>
           {label}
           <DownOutlined />
         </Button>


### PR DESCRIPTION
### Description

Seems to not be working based on label. Additionally, 'green' is no longer a part of the color palette.

<img width="122" alt="image" src="https://user-images.githubusercontent.com/18120418/83192180-2ff85880-a103-11ea-9f38-1e56bc7c4014.png">

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Change Status
- [x] Complete, but not tested (may need new tests)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] There are no merge conflicts
